### PR TITLE
feat: Add reason output to the statements metric

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,9 @@ repos:
   hooks:
   - id: mypy
     args: [--ignore-missing-imports]
+    additional_dependencies:
+    - pydantic
+
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
   rev: v2.14.0
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev-dependencies = [
     "pytest-asyncio>=0.25.3",
     "ruff>=0.8.1",
     "pdoc>=15.0.1",
+    "pytest-mock>=3.14.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/mirror_eval/core/config.py
+++ b/src/mirror_eval/core/config.py
@@ -30,7 +30,7 @@ def get_settings() -> Settings:
 
 def get_logger() -> logging.Logger:
     """Gets the ctk-functions logger."""
-    logger = logging.getLogger("ctk-functions")
+    logger = logging.getLogger("mirror-eval")
     if logger.hasHandlers():
         return logger
 

--- a/src/mirror_eval/opik/metric.py
+++ b/src/mirror_eval/opik/metric.py
@@ -345,13 +345,25 @@ class LlmStatementMetric(base_metric.BaseMetric):
         Returns:
             A ScoreResults wherein the value is the average score.
         """
-        dict_content = json.loads(content)
+
+        def response_to_string(statement: Statement) -> str:
+            return (
+                f"Statement: {statement.statement}"
+                f"\nEvaluation: {statement.evaluation}"
+                f"\nConclusion: {statement.conclusion}"
+            )
+
+        response = StatementResponse.model_validate_json(content)
         score = statistics.mean(
-            response["conclusion"] for response in dict_content["statements"]
+            statement.conclusion for statement in response.statements
+        )
+        reason = "\n\n".join(
+            response_to_string(statement) for statement in response.statements
         )
         return score_result.ScoreResult(
             name=self._name,
             value=score,
+            reason=reason,
         )
 
 

--- a/src/mirror_eval/opik/metric.py
+++ b/src/mirror_eval/opik/metric.py
@@ -316,7 +316,8 @@ class LlmStatementMetric(base_metric.BaseMetric):
             except litellm.BadRequestError as exc_info:
                 if "Invalid schema for response_format" in str(exc_info):
                     logger.warning(
-                        "Could not run this model with strict properties. Retrying without...",
+                        "Could not run this model with strict properties. "
+                        "Retrying without...",
                         exc_info=exc_info,
                     )
                     model_output = await self._model.agenerate_string(

--- a/src/mirror_eval/opik/metric.py
+++ b/src/mirror_eval/opik/metric.py
@@ -288,7 +288,8 @@ class LlmStatementMetric(base_metric.BaseMetric):
         if not self._statements_tracked:
             self._track_statements(self._statements)
 
-        prompt = self._get_prompt(input, output)
+        preamble = '\n\n[{\n    "statement": '
+        prompt = self._get_prompt(input, output) + preamble
         if strict is None:
             try:
                 model_output = self._model.generate_string(
@@ -313,7 +314,7 @@ class LlmStatementMetric(base_metric.BaseMetric):
                 input=prompt,
                 response_format=self._get_response_model(strict=strict),
             )
-        return self._parse_model_output(model_output)
+        return self._parse_model_output(preamble + model_output)
 
     async def ascore(
         self,
@@ -339,7 +340,8 @@ class LlmStatementMetric(base_metric.BaseMetric):
         if not self._statements_tracked:
             self._track_statements(self._statements)
 
-        prompt = self._get_prompt(input, output)
+        preamble = '\n\n[{\n    "statement": '
+        prompt = self._get_prompt(input, output) + preamble
         if strict is None:
             try:
                 model_output = await self._model.agenerate_string(
@@ -364,7 +366,7 @@ class LlmStatementMetric(base_metric.BaseMetric):
                 input=prompt,
                 response_format=self._get_response_model(strict=strict),
             )
-        return self._parse_model_output(model_output)
+        return self._parse_model_output(preamble + model_output)
 
     def _get_prompt(self, input: str, output: str) -> str:  # noqa: A002
         """Gets the input prompt for scoring.

--- a/src/mirror_eval/opik/metric.py
+++ b/src/mirror_eval/opik/metric.py
@@ -345,21 +345,11 @@ class LlmStatementMetric(base_metric.BaseMetric):
         Returns:
             A ScoreResults wherein the value is the average score.
         """
-
-        def response_to_string(statement: Statement) -> str:
-            return (
-                f"Statement: {statement.statement}"
-                f"\nEvaluation: {statement.evaluation}"
-                f"\nConclusion: {statement.conclusion}"
-            )
-
         response = StatementResponse.model_validate_json(content)
         score = statistics.mean(
             statement.conclusion for statement in response.statements
         )
-        reason = "\n\n".join(
-            response_to_string(statement) for statement in response.statements
-        )
+        reason = response.model_dump_json(indent=4)
         return score_result.ScoreResult(
             name=self._name,
             value=score,

--- a/tests/unit/test_metric.py
+++ b/tests/unit/test_metric.py
@@ -109,7 +109,23 @@ async def test_statement_metric(use_async: bool) -> None:  # noqa: FBT001
     statements = ["This text is in French."]
     input_text = "An input text."
     output_text = "Oui, ce texte est en français."
-    mock_model = MockOpikModel(output='{"statements": [{"conclusion": true}]}')
+    mock_model = MockOpikModel(
+        output="""
+            {"statements":
+                [
+                    {
+                        "statement": "This is English.",
+                        "evaluation": "It really is.",
+                        "conclusion": true
+                    }
+                ]
+            }
+        """
+    )
+    expected_reason = (
+        "Statement: This is English.\nEvaluation: It really is.\nConclusion: True"
+    )
+
     statement_metric = metric.LlmStatementMetric(statements, mock_model)
 
     if use_async:
@@ -119,6 +135,7 @@ async def test_statement_metric(use_async: bool) -> None:  # noqa: FBT001
 
     assert result.name == "Statement Model"
     assert result.value == 1
+    assert result.reason == expected_reason
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_metric.py
+++ b/tests/unit/test_metric.py
@@ -109,22 +109,16 @@ async def test_statement_metric(use_async: bool) -> None:  # noqa: FBT001
     statements = ["This text is in French."]
     input_text = "An input text."
     output_text = "Oui, ce texte est en français."
-    mock_model = MockOpikModel(
-        output="""
-            {"statements":
-                [
-                    {
-                        "statement": "This is English.",
-                        "evaluation": "It really is.",
-                        "conclusion": true
-                    }
-                ]
-            }
-        """
-    )
-    expected_reason = (
-        "Statement: This is English.\nEvaluation: It really is.\nConclusion: True"
-    )
+    output = """{
+    "statements": [
+        {
+            "statement": "This is English.",
+            "evaluation": "It really is.",
+            "conclusion": true
+        }
+    ]
+}"""
+    mock_model = MockOpikModel(output=output)
 
     statement_metric = metric.LlmStatementMetric(statements, mock_model)
 
@@ -135,7 +129,9 @@ async def test_statement_metric(use_async: bool) -> None:  # noqa: FBT001
 
     assert result.name == "Statement Model"
     assert result.value == 1
-    assert result.reason == expected_reason
+    assert (
+        result.reason.lower() == output.lower()
+    )  # .lower() because JSON uses lowercase True.
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_metric.py
+++ b/tests/unit/test_metric.py
@@ -115,16 +115,12 @@ async def test_statement_metric_strict(use_async: bool) -> None:  # noqa: FBT001
     mock_model = MockOpikModel(
         output=' "", "conclusion": true}]'
     )  # Accounts for JSON preamble included in the scoring function.
-    statement_metric = metric.LlmStatementMetric(statements, mock_model)
+    statement_metric = metric.LlmStatementMetric(statements, mock_model, strict=True)
 
     if use_async:
-        result = await statement_metric.ascore(
-            input=input_text, output=output_text, strict=True
-        )
+        result = await statement_metric.ascore(input=input_text, output=output_text)
     else:
-        result = statement_metric.score(
-            input=input_text, output=output_text, strict=True
-        )
+        result = statement_metric.score(input=input_text, output=output_text)
 
     assert result.name == "Statement Model"
     assert result.value == 1

--- a/uv.lock
+++ b/uv.lock
@@ -641,6 +641,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-mock" },
     { name = "ruff" },
 ]
 
@@ -662,6 +663,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "ruff", specifier = ">=0.8.1" },
 ]
 
@@ -1078,6 +1080,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949 },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/90/a955c3ab35ccd41ad4de556596fa86685bf4fc5ffcc62d22d856cfd4e29a/pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0", size = 32814 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/3b/b26f90f74e2986a82df6e7ac7e319b8ea7ccece1caec9f8ab6104dc70603/pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f", size = 9863 },
 ]
 
 [[package]]


### PR DESCRIPTION
This adds a basic reasoning output to the statements metric so we can inspect which statements tend to fail. 

Note: to avoid merge conflicts, this PR is based on #9 . That PR should be merged first. 